### PR TITLE
Add predicate filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.15",
+    "@types/node": "^12.6.8",
     "@types/react": "^16.8.19",
     "codecov": "^3.5.0",
     "jest": "^24.8.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -150,6 +150,52 @@ describe("namespaced events", () => {
     ]);
   });
 });
+describe("filtering by predicate", () => {
+  it("should filter event subscription using a predicate function", () => {
+    // mock subscription
+    const handleAllSubscriptions = jest.fn();
+    const handleThingsSubscriptions = jest.fn();
+
+    type ThingsSave = {
+      type: "things.save";
+      payload: string;
+    };
+    const createSaveEvent = defineEvent<ThingsSave>("things.save");
+
+    type ThingsEdit = {
+      type: "things.edit";
+      payload: string;
+    };
+    const createEditEvent = defineEvent<ThingsEdit>("things.edit");
+
+    type Frogs = {
+      type: "frogs";
+      payload: string;
+    };
+    const createFrogs = defineEvent<Frogs>("frogs");
+
+    const bus = new EventBus();
+    bus.subscribe(() => true, handleAllSubscriptions);
+    bus.subscribe(
+      ({ type }) => /^things\./.test(type),
+      handleThingsSubscriptions
+    );
+
+    bus.publish(createEditEvent("Foo"));
+    bus.publish(createSaveEvent("Bar"));
+    bus.publish(createFrogs("Gribbit"));
+
+    expect(handleAllSubscriptions.mock.calls).toEqual([
+      [{ payload: "Foo", type: "things.edit" }],
+      [{ payload: "Bar", type: "things.save" }],
+      [{ payload: "Gribbit", type: "frogs" }]
+    ]);
+    expect(handleThingsSubscriptions.mock.calls).toEqual([
+      [{ payload: "Foo", type: "things.edit" }],
+      [{ payload: "Bar", type: "things.save" }]
+    ]);
+  });
+});
 
 describe("unsubsubscribe from events", () => {
   it("should handle unsubscribing", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,6 +350,11 @@
   dependencies:
     "@types/jest-diff" "*"
 
+"@types/node@^12.6.8":
+  version "12.6.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
+  integrity sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==
+
 "@types/prop-types@*":
   version "15.7.1"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"


### PR DESCRIPTION
This PR adds the ability to use a predicate function to ts-bus. 

```ts
const isSharedAndLocalEvent = event =>
  /^shared\./.test(event.type) && !(event.meta && event.meta.remote);

bus.subscribe(isSharedAndLocalEvent, event => {
  // ...
});
```

