### PR TITLE
New `createEventDefinition` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To explore an example of ts-bs used in context pease see the [KanBan example](ex
 
 ## Usage
 
-#### Create a bus
+### Create a bus
 
 Create your EventBus globally somewhere:
 
@@ -84,7 +84,7 @@ import { EventBus } from "ts-bus";
 export const bus = new EventBus();
 ```
 
-#### Declare events
+### Declare events
 
 Next create some Events:
 
@@ -106,7 +106,7 @@ export const taskLabelUpdated = createEventDefinition<{
 
 Notice we need to call the curried function to create the event creator this is because it is [the only way we can allow effective discriminated unions](https://github.com/ryardley/ts-bus/issues/9).
 
-#### Runtime payload checking
+### Runtime payload checking
 
 You can also provide a function to do runtime payload type checking. This might be useful if you are working in JavaScript:
 
@@ -118,7 +118,7 @@ export const taskLabelUpdated = createEventDefinition(p`{
 }`)("task.label.updated");
 ```
 
-#### Subscription
+### Subscription
 
 Let's subscribe to our events
 
@@ -150,7 +150,7 @@ bus.subscribe(taskCreated, event => {
 });
 ```
 
-#### Publishing events
+### Publishing events
 
 Now let's publish our events somewhere
 
@@ -218,7 +218,7 @@ This is inherited directly from EventEmitter2 which ts-bus currently uses under 
 
 Included with `ts-bus` are some React hooks and helpers that provide a bus context as well as facilitate state management within React.
 
-#### BusProvider
+### BusProvider
 
 Wrap your app using the `BusProvider`
 
@@ -240,7 +240,7 @@ export default () => (
 );
 ```
 
-#### useBus
+### useBus
 
 Access the bus instance with `useBus`
 
@@ -262,7 +262,7 @@ function ProcessButton(props) {
 }
 ```
 
-#### useBusReducer
+### useBusReducer
 
 This connects state changes to bus events via a state reducer function.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ export const taskLabelUpdated = createEventDefinition<{
 
 Notice we need to call the curried function to create the event creator this is because it is [the only way we can allow effective discriminated unions](https://github.com/ryardley/ts-bus/issues/9).
 
-##### TIP: Runtime payload checking
+#### Runtime payload checking
 
 You can also provide a function to do runtime payload type checking. This might be useful if you are working in JavaScript:
 

--- a/examples/kanban/src/modules/board/events.ts
+++ b/examples/kanban/src/modules/board/events.ts
@@ -2,57 +2,40 @@ import produce from "immer";
 
 import { Task, List } from "./types";
 
-import { defineEvent } from "../../../../../dist";
+import { createEventDefinition } from "../../../../../dist";
 
-export const taskMoved = defineEvent<{
-  type: "shared.task.moved";
-  payload: {
-    source: { id: string; index: number };
-    destination: { id: string; index: number };
-  };
-}>("shared.task.moved");
+export const taskMoved = createEventDefinition<{
+  source: { id: string; index: number };
+  destination: { id: string; index: number };
+}>()("shared.task.moved");
 
-export const taskCreated = defineEvent<{
-  type: "shared.task.created";
-  payload: {
-    id: string;
-    listId: string;
-    value: string;
-  };
-}>("shared.task.created");
+export const taskCreated = createEventDefinition<{
+  id: string;
+  listId: string;
+  value: string;
+}>()("shared.task.created");
 
-export const taskUpdated = defineEvent<{
-  type: "shared.task.updated";
-  payload: {
-    id: string;
-    task: { label: string };
-  };
-}>("shared.task.updated");
+export const taskUpdated = createEventDefinition<{
+  id: string;
+  task: { label: string };
+}>()("shared.task.updated");
 
-export const taskDeleted = defineEvent<{
-  type: "shared.task.deleted";
-  payload: {
-    id: string;
-  };
-}>("shared.task.deleted");
+export const taskDeleted = createEventDefinition<{
+  id: string;
+}>()("shared.task.deleted");
 
-export const listCreated = defineEvent<{
-  type: "shared.list.created";
-  payload: { id: string };
-}>("shared.list.created");
+export const listCreated = createEventDefinition<{ id: string }>()(
+  "shared.list.created"
+);
 
-export const listTitleChanged = defineEvent<{
-  type: "shared.list.title.changed";
-  payload: {
-    id: string;
-    title: string;
-  };
-}>("shared.list.title.changed");
+export const listTitleChanged = createEventDefinition<{
+  id: string;
+  title: string;
+}>()("shared.list.title.changed");
 
-export const listDeleted = defineEvent<{
-  type: "shared.list.deleted";
-  payload: { id: string };
-}>("shared.list.deleted");
+export const listDeleted = createEventDefinition<{ id: string }>()(
+  "shared.list.deleted"
+);
 
 export type BoardEvent =
   | ReturnType<typeof taskMoved>

--- a/examples/kanban/src/modules/routes/events.ts
+++ b/examples/kanban/src/modules/routes/events.ts
@@ -1,18 +1,15 @@
-import { defineEvent } from "../../../../../dist";
+import { createEventDefinition } from "../../../../../dist";
 
-export const navigationRequested = defineEvent<{
-  type: "navigation.request";
-  payload: {
-    to:
-      | string
-      | {
-          pathname: string;
-          search: string;
-          hash: string;
-          state: any;
-        };
-    replace?: boolean;
-  };
-}>("navigation.request");
+export const navigationRequested = createEventDefinition<{
+  to:
+    | string
+    | {
+        pathname: string;
+        search: string;
+        hash: string;
+        state: any;
+      };
+  replace?: boolean;
+}>()("navigation.request");
 
 export type RouteEvent = ReturnType<typeof navigationRequested>;

--- a/src/EventBus.ts
+++ b/src/EventBus.ts
@@ -29,18 +29,26 @@ function isPredicateFn(descriptor: any): descriptor is PredicateFn {
   return !isEventDescriptor(descriptor) && typeof descriptor === "function";
 }
 
+type TestPredicateFn<P> = (payload: P) => boolean;
+
 type EventDefinitionOptions<P> = {
   test?: (payload: P) => boolean;
 };
 
-export function createEventDefinition<P>(options?: EventDefinitionOptions<P>) {
+export function createEventDefinition<P>(
+  options?: EventDefinitionOptions<P> | TestPredicateFn<P>
+) {
   return <T extends string>(type: T) => {
     const eventCreator = (payload: P) => {
       // Allow runtime payload checking for plain JavaScript usage
-      if (options && options.test && !options.test(payload)) {
-        showWarning(
-          `${JSON.stringify(payload)} does not match expected payload.`
-        );
+
+      if (options) {
+        const testFn = typeof options === "function" ? options : options.test;
+        if (testFn && !testFn(payload)) {
+          showWarning(
+            `${JSON.stringify(payload)} does not match expected payload.`
+          );
+        }
       }
 
       return {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -79,6 +79,14 @@ describe("Basic usage", () => {
         `{"ding":"baz"} does not match expected payload.`
       );
     });
+
+    it("should allow string coercion to return the eventType", () => {
+      const myEventCreator = createEventDefinition<{
+        foo: string;
+      }>()("myevent");
+
+      expect(String(myEventCreator)).toEqual("myevent");
+    });
   });
 
   it("should respond to events being dispatched", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,65 +4,81 @@ const mockWarn = jest.fn();
 console.warn = mockWarn;
 
 describe("Basic usage", () => {
-  it("should work with createEventDefinition", () => {
-    // mock subscription
-    const handleSubscription = jest.fn();
+  describe("createEventDefinition", () => {
+    it("should work with createEventDefinition", () => {
+      // mock subscription
+      const handleSubscription = jest.fn();
 
-    const myEventCreator = createEventDefinition<{
-      foo: string;
-    }>()("myevent");
+      const myEventCreator = createEventDefinition<{
+        foo: string;
+      }>()("myevent");
 
-    // create a bus
-    const bus = new EventBus();
-    bus.subscribe(myEventCreator, handleSubscription);
+      // create a bus
+      const bus = new EventBus();
+      bus.subscribe(myEventCreator, handleSubscription);
 
-    // create n event
-    const event = myEventCreator({ foo: "Hello" });
+      // create n event
+      const event = myEventCreator({ foo: "Hello" });
 
-    // Call it once
-    bus.publish(event);
-    expect(handleSubscription.mock.calls).toEqual([
-      [
-        {
-          type: "myevent",
-          payload: { foo: "Hello" }
-        }
-      ]
-    ]);
+      // Call it once
+      bus.publish(event);
+      expect(handleSubscription.mock.calls).toEqual([
+        [
+          {
+            type: "myevent",
+            payload: { foo: "Hello" }
+          }
+        ]
+      ]);
 
-    // call a few times
-    bus.publish(event);
-    bus.publish(event);
-    bus.publish(event);
+      // call a few times
+      bus.publish(event);
+      bus.publish(event);
+      bus.publish(event);
 
-    expect(handleSubscription.mock.calls.length).toBe(4);
-  });
+      expect(handleSubscription.mock.calls.length).toBe(4);
+    });
 
-  it("should show deprecation warning when using defineEvent", () => {
-    mockWarn.mockReset();
+    it("should show deprecation warning when using defineEvent", () => {
+      mockWarn.mockReset();
 
-    defineEvent<{
-      type: "myevent";
-      payload: { foo: string };
-    }>("myevent");
+      defineEvent<{
+        type: "myevent";
+        payload: { foo: string };
+      }>("myevent");
 
-    expect(mockWarn.mock.calls[0][0]).toEqual(
-      "defineEvent is deprecated and will be removed in the future. Please use createEventDefinition instead."
-    );
-  });
+      expect(mockWarn.mock.calls[0][0]).toEqual(
+        "defineEvent is deprecated and will be removed in the future. Please use createEventDefinition instead."
+      );
+    });
 
-  it("should allow runtime type warnings", () => {
-    mockWarn.mockReset();
-    const testFn = (o: any) => o.foo && typeof o.foo === "string";
-    const myEventCreator = createEventDefinition<{
-      foo: string;
-    }>({ test: testFn })("myevent");
+    it("should allow runtime type warnings", () => {
+      mockWarn.mockReset();
+      const testFn = (o: any) => o.foo && typeof o.foo === "string";
+      const myEventCreator = createEventDefinition<{
+        foo: string;
+      }>(testFn)("myevent");
 
-    // @ts-ignore
-    myEventCreator({ ding: "baz" });
-    expect(mockWarn.mock.calls[0][0]).toEqual(
-      `{"ding":"baz"} does not match expected payload.`
-    );
+      // @ts-ignore
+      myEventCreator({ ding: "baz" });
+      expect(mockWarn.mock.calls[0][0]).toEqual(
+        `{"ding":"baz"} does not match expected payload.`
+      );
+    });
+
+    it("should allow runtime type warnings with the options object", () => {
+      mockWarn.mockReset();
+      const testFn = (o: any) => o.foo && typeof o.foo === "string";
+      const myEventCreator = createEventDefinition<{
+        foo: string;
+      }>({ test: testFn })("myevent");
+
+      // @ts-ignore
+      myEventCreator({ ding: "baz" });
+      expect(mockWarn.mock.calls[0][0]).toEqual(
+        `{"ding":"baz"} does not match expected payload.`
+      );
+    });
   });
 
   it("should respond to events being dispatched", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -51,6 +51,20 @@ describe("Basic usage", () => {
     );
   });
 
+  it("should allow runtime type warnings", () => {
+    mockWarn.mockReset();
+    const testFn = (o: any) => o.foo && typeof o.foo === "string";
+    const myEventCreator = createEventDefinition<{
+      foo: string;
+    }>({ test: testFn })("myevent");
+
+    // @ts-ignore
+    myEventCreator({ ding: "baz" });
+    expect(mockWarn.mock.calls[0][0]).toEqual(
+      `{"ding":"baz"} does not match expected payload.`
+    );
+  });
+
   it("should respond to events being dispatched", () => {
     // mock subscription
     const handleSubscription = jest.fn();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,56 @@
-import { EventBus, defineEvent } from "./index";
+import { EventBus, defineEvent, createEventDefinition } from "./index";
+
+const mockWarn = jest.fn();
+console.warn = mockWarn;
 
 describe("Basic usage", () => {
+  it("should work with createEventDefinition", () => {
+    // mock subscription
+    const handleSubscription = jest.fn();
+
+    const myEventCreator = createEventDefinition<{
+      foo: string;
+    }>()("myevent");
+
+    // create a bus
+    const bus = new EventBus();
+    bus.subscribe(myEventCreator, handleSubscription);
+
+    // create n event
+    const event = myEventCreator({ foo: "Hello" });
+
+    // Call it once
+    bus.publish(event);
+    expect(handleSubscription.mock.calls).toEqual([
+      [
+        {
+          type: "myevent",
+          payload: { foo: "Hello" }
+        }
+      ]
+    ]);
+
+    // call a few times
+    bus.publish(event);
+    bus.publish(event);
+    bus.publish(event);
+
+    expect(handleSubscription.mock.calls.length).toBe(4);
+  });
+
+  it("should show deprecation warning when using defineEvent", () => {
+    mockWarn.mockReset();
+
+    defineEvent<{
+      type: "myevent";
+      payload: { foo: string };
+    }>("myevent");
+
+    expect(mockWarn.mock.calls[0][0]).toEqual(
+      "defineEvent is deprecated and will be removed in the future. Please use createEventDefinition instead."
+    );
+  });
+
   it("should respond to events being dispatched", () => {
     // mock subscription
     const handleSubscription = jest.fn();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { EventBus, defineEvent } from "./EventBus";
+export { EventBus, defineEvent, createEventDefinition } from "./EventBus";


### PR DESCRIPTION
### PR Summary

Not a breaking change but includes a deprecation. 

In response to https://github.com/ryardley/ts-bus/issues/9

* New `createEventDefinition` method
* Deprecate `defineEvent`
* Allow runtime payload checking
* Update documentation
* Update example application

TypeScript Example

```ts
import { createEventDefinition } from "ts-bus";

export const taskCreated = createEventDefinition<{
  id: string;
  listId: string;
  value: string;
}>()("task.created");
```

JavaScript Example

```js
import { createEventDefinition } from "ts-bus";
import p from "pdsl";

export const taskLabelUpdated = createEventDefinition(p`{
  id: String,
  label: String,
}`)("task.label.updated");
```

