### PR TITLE
Events without payloads

### DIFF
--- a/src/EventBus.ts
+++ b/src/EventBus.ts
@@ -29,17 +29,31 @@ function isPredicateFn(descriptor: any): descriptor is PredicateFn {
   return !isEventDescriptor(descriptor) && typeof descriptor === "function";
 }
 
-type TestPredicateFn<P = undefined> = (payload: P | undefined) => boolean;
+type TestPredicateFn<P> = (payload: P) => boolean;
 
-type EventDefinitionOptions<P = undefined> = {
-  test?: (payload: P | undefined) => boolean;
+type EventDefinitionOptions<P> = {
+  test?: (payload: P) => boolean;
 };
 
-export function createEventDefinition<P = undefined>(
+export function createEmptyEventDefinition() {
+  return <T extends string>(type: T) => {
+    const eventCreator = () => {
+      return {
+        type,
+        payload: undefined
+      };
+    };
+    eventCreator.eventType = type;
+    eventCreator.toString = () => type; // allow String coercion to deliver the eventType
+    return eventCreator;
+  };
+}
+
+export function createEventDefinition<P>(
   options?: EventDefinitionOptions<P> | TestPredicateFn<P>
 ) {
   return <T extends string>(type: T) => {
-    const eventCreator = (payload?: P) => {
+    const eventCreator = (payload: P) => {
       // Allow runtime payload checking for plain JavaScript usage
 
       if (options) {

--- a/src/EventBus.ts
+++ b/src/EventBus.ts
@@ -29,10 +29,10 @@ function isPredicateFn(descriptor: any): descriptor is PredicateFn {
   return !isEventDescriptor(descriptor) && typeof descriptor === "function";
 }
 
-type TestPredicateFn<P> = (payload: P) => boolean;
+type TestPredicateFn<P = undefined> = (payload: P | undefined) => boolean;
 
-type EventDefinitionOptions<P> = {
-  test?: (payload: P) => boolean;
+type EventDefinitionOptions<P = undefined> = {
+  test?: (payload: P | undefined) => boolean;
 };
 
 export function createEventDefinition<P = undefined>(
@@ -44,7 +44,7 @@ export function createEventDefinition<P = undefined>(
 
       if (options) {
         const testFn = typeof options === "function" ? options : options.test;
-        if (testFn && payload !== undefined && !testFn(payload)) {
+        if (testFn && !testFn(payload)) {
           showWarning(
             `${JSON.stringify(payload)} does not match expected payload.`
           );

--- a/src/EventBus.ts
+++ b/src/EventBus.ts
@@ -35,16 +35,16 @@ type EventDefinitionOptions<P> = {
   test?: (payload: P) => boolean;
 };
 
-export function createEventDefinition<P>(
+export function createEventDefinition<P = undefined>(
   options?: EventDefinitionOptions<P> | TestPredicateFn<P>
 ) {
   return <T extends string>(type: T) => {
-    const eventCreator = (payload: P) => {
+    const eventCreator = (payload?: P) => {
       // Allow runtime payload checking for plain JavaScript usage
 
       if (options) {
         const testFn = typeof options === "function" ? options : options.test;
-        if (testFn && !testFn(payload)) {
+        if (testFn && payload !== undefined && !testFn(payload)) {
           showWarning(
             `${JSON.stringify(payload)} does not match expected payload.`
           );

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -39,6 +39,31 @@ describe("Basic usage", () => {
       expect(handleSubscription.mock.calls.length).toBe(4);
     });
 
+    it("should work without payload type declaration", () => {
+      // mock subscription
+      const handleSubscription = jest.fn();
+
+      const myEventCreator = createEventDefinition()("myevent");
+
+      // create a bus
+      const bus = new EventBus();
+      bus.subscribe(myEventCreator, handleSubscription);
+
+      // create n event
+      const event = myEventCreator();
+
+      // Call it once
+      bus.publish(event);
+      expect(handleSubscription.mock.calls).toEqual([
+        [
+          {
+            type: "myevent",
+            payload: undefined
+          }
+        ]
+      ]);
+    });
+
     it("should show deprecation warning when using defineEvent", () => {
       mockWarn.mockReset();
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -90,9 +90,6 @@ describe("Basic usage", () => {
     });
   });
 
-
-
-//////////////////////////////
 describe("createEmptyEventDefinition", () => {
   it("should work with createEmptyEventDefinition", () => {
     // mock subscription
@@ -127,7 +124,6 @@ describe("createEmptyEventDefinition", () => {
   });
 
 });
-///////////////////////////////
 
   it("should respond to events being dispatched", () => {
     // mock subscription

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import { EventBus, defineEvent, createEventDefinition } from "./index";
+import { createEmptyEventDefinition } from "./EventBus";
 
 const mockWarn = jest.fn();
 console.warn = mockWarn;
@@ -37,31 +38,6 @@ describe("Basic usage", () => {
       bus.publish(event);
 
       expect(handleSubscription.mock.calls.length).toBe(4);
-    });
-
-    it("should work without payload type declaration", () => {
-      // mock subscription
-      const handleSubscription = jest.fn();
-
-      const myEventCreator = createEventDefinition()("myevent");
-
-      // create a bus
-      const bus = new EventBus();
-      bus.subscribe(myEventCreator, handleSubscription);
-
-      // create n event
-      const event = myEventCreator();
-
-      // Call it once
-      bus.publish(event);
-      expect(handleSubscription.mock.calls).toEqual([
-        [
-          {
-            type: "myevent",
-            payload: undefined
-          }
-        ]
-      ]);
     });
 
     it("should show deprecation warning when using defineEvent", () => {
@@ -113,6 +89,45 @@ describe("Basic usage", () => {
       expect(String(myEventCreator)).toEqual("myevent");
     });
   });
+
+
+
+//////////////////////////////
+describe("createEmptyEventDefinition", () => {
+  it("should work with createEmptyEventDefinition", () => {
+    // mock subscription
+    const handleSubscription = jest.fn();
+
+    const myEventCreator = createEmptyEventDefinition()("myevent");
+
+    // create a bus
+    const bus = new EventBus();
+    bus.subscribe(myEventCreator, handleSubscription);
+
+    // create n event
+    const event = myEventCreator();
+
+    // Call it once
+    bus.publish(event);
+    expect(handleSubscription.mock.calls).toEqual([
+      [
+        {
+          type: "myevent",
+          payload: undefined
+        }
+      ]
+    ]);
+
+    // call a few times
+    bus.publish(event);
+    bus.publish(event);
+    bus.publish(event);
+
+    expect(handleSubscription.mock.calls.length).toBe(4);
+  });
+
+});
+///////////////////////////////
 
   it("should respond to events being dispatched", () => {
     // mock subscription


### PR DESCRIPTION
Sometimes you just want to publish a event without any any payload. Currently it's possible to use the `createEventDefinition` without the type declaration. However, the event creator method still forces you to pass in some dummy `payload`.

```ts
const creator = createEventDefinition()("eventname");
const event = creator({});
```

This PR solves this problem by introducing the function `createEmptyEventDefinition` which sets the generic parameter to `undefined`. Not sure whether a generic parameter should be `undefined` but at least this way it's obvious that the payload is empty and also the IDE will highlight an error if you type `myevent.payload.property`.

```ts
const creator = createEmptyEventDefinition()("eventname");
const event = creator();
```


Another option would be to introduce another event type without the `payload` property. But that would be too much overhead to maintain...

@ryardley What's your view on this?