### PR TITLE
Prevent memory leak in defaultSubscriber

### DIFF
--- a/src/react.test.tsx
+++ b/src/react.test.tsx
@@ -29,7 +29,7 @@ it("should not subscribe without unsubscribing ", () => {
   const mockBus = mockEventBus();
 
   // run once to subscribe to bus
-  const { rerender } = renderHook(
+  const hook = renderHook(
     (subscriberFn: (d: any, b: any) => void) =>
       useBusReducer({}, (state: {}) => state, subscriberFn),
     {
@@ -41,10 +41,11 @@ it("should not subscribe without unsubscribing ", () => {
   );
 
   // change subscriber to different reference to invalidate useEffect
-  rerender((...args) => _defaultSubscriber(...args));
+  hook.rerender((...args) => _defaultSubscriber(...args));
+  hook.unmount();
 
   expect(mockBus.subscribe.mock.calls.length).toBe(2);
-  expect(mockBus._unsubscribe.mock.calls.length).toBe(1);
+  expect(mockBus._unsubscribe.mock.calls.length).toBe(2);
 });
 
 it("should reduce state", () => {

--- a/src/useBusReducer.ts
+++ b/src/useBusReducer.ts
@@ -5,11 +5,11 @@ import { BusEvent } from "./types";
 
 type DispatchFn<E> = (a: E) => void;
 
-function defaultSubscriber<E extends BusEvent>(
+export function _defaultSubscriber<E extends BusEvent>(
   dispatch: DispatchFn<E>,
   bus: EventBus
 ) {
-  bus.subscribe<E>("**", dispatch);
+  return bus.subscribe<E>("**", dispatch);
 }
 
 export function useBusReducer<E extends BusEvent = BusEvent, T = any>(
@@ -18,7 +18,7 @@ export function useBusReducer<E extends BusEvent = BusEvent, T = any>(
   subscriber: (
     dispatch: DispatchFn<E>,
     bus: EventBus
-  ) => void = defaultSubscriber
+  ) => void = _defaultSubscriber
 ) {
   // Pull the bus from context
   const bus = useBus();


### PR DESCRIPTION
In the discussion around https://github.com/ryardley/ts-bus/issues/23#issuecomment-521470182 I discovered there is a subtle bug in the way we handle our default subscriber. Which probably would never have been triggered an inconsistent state but would have caused a memory leak as components were unmounted. 