### PR TITLE
Fix missing events during render

### DIFF
--- a/src/react.test.tsx
+++ b/src/react.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { create, act as rAct } from "react-test-renderer";
 
 import { renderHook, act } from "@testing-library/react-hooks";
 import { BusProvider, useBus, useBusReducer } from "./react";
@@ -134,4 +135,55 @@ it("should subscribe state", () => {
 
   // Reset should have no effect because of subscriber
   expect(result.current.counter).toBe(1);
+});
+
+it("should not loose events during the render cycle when mounted ", done => {
+  const myBus = new EventBus();
+  const reducer = jest.fn(s => s);
+
+  const EVENT_DELAY = { type: "myevent", payload: "DELAY" };
+  const EVENT_URGENT = { type: "myevent", payload: "URGENT" };
+
+  function MyContextProvider(props: { children: any }) {
+    useBusReducer({}, reducer);
+
+    return props.children;
+  }
+
+  function EventPublisher() {
+    const b = useBus();
+
+    React.useEffect(() => {
+      setTimeout(() => {
+        b.publish(EVENT_DELAY);
+      }, 0);
+    }, [b]);
+
+    React.useEffect(() => {
+      b.publish(EVENT_URGENT);
+    }, [b]);
+
+    return <div />;
+  }
+
+  function App() {
+    return (
+      <BusProvider value={myBus}>
+        <MyContextProvider>
+          <EventPublisher />
+        </MyContextProvider>
+      </BusProvider>
+    );
+  }
+
+  // render the component
+  act(() => {
+    create(<App />);
+  });
+
+  setTimeout(() => {
+    const eventList = reducer.mock.calls.map(([, ev]: any[]) => ev);
+    expect(eventList).toEqual([EVENT_URGENT, EVENT_DELAY]);
+    done();
+  }, 0);
 });

--- a/src/react.test.tsx
+++ b/src/react.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { create, act as rAct } from "react-test-renderer";
+import { create } from "react-test-renderer";
 
 import { renderHook, act } from "@testing-library/react-hooks";
 import { BusProvider, useBus, useBusReducer } from "./react";

--- a/src/react.test.tsx
+++ b/src/react.test.tsx
@@ -137,7 +137,7 @@ it("should subscribe state", () => {
   expect(result.current.counter).toBe(1);
 });
 
-it("should not loose events during the render cycle when mounted ", done => {
+it("should not loose events during the render cycle when mounted.", done => {
   const myBus = new EventBus();
   const reducer = jest.fn(s => s);
 

--- a/src/useBusReducer.ts
+++ b/src/useBusReducer.ts
@@ -1,4 +1,4 @@
-import { useReducer, useEffect } from "react";
+import { useReducer, useLayoutEffect } from "react";
 import { useBus } from "./react";
 import { EventBus } from "./EventBus";
 import { BusEvent } from "./types";
@@ -27,7 +27,7 @@ export function useBusReducer<E extends BusEvent = BusEvent, T = any>(
   const [state, dispatch] = useReducer(reducer, initState);
 
   // Run the subscriber
-  useEffect(() => subscriber(dispatch, bus), [subscriber, dispatch, bus]);
+  useLayoutEffect(() => subscriber(dispatch, bus), [subscriber, dispatch, bus]);
 
   return state;
 }

--- a/src/useBusReducer.ts
+++ b/src/useBusReducer.ts
@@ -26,7 +26,7 @@ export function useBusReducer<E extends BusEvent = BusEvent, T = any>(
   // Run the reducer
   const [state, dispatch] = useReducer(reducer, initState);
 
-  // Run the subscriber
+  // Run the subscriber synchronously
   useLayoutEffect(() => subscriber(dispatch, bus), [subscriber, dispatch, bus]);
 
   return state;


### PR DESCRIPTION
This PR fixes the bug where `useBusReducer` was loosing initial events that fired between the render and running of `useEffect`. This issue was described here: https://github.com/ryardley/ts-bus/issues/23

It works by replacing `useEffect` with `useLayoutEffect` which runs synchronously during the render process.


