### PR TITLE
Breaking Change: Configuration syntax

### DIFF
--- a/examples/kanban/src/modules/board/app.tsx
+++ b/examples/kanban/src/modules/board/app.tsx
@@ -6,7 +6,7 @@ import { initState, reducer, BoardEvent } from "./events";
 export const BoardContext = React.createContext(initState);
 
 function BoardApp({ children }: { children: React.ReactNode }) {
-  const state = useBusReducer<BoardEvent>(initState, reducer);
+  const state = useBusReducer<BoardEvent>(reducer, initState);
 
   return (
     <BoardContext.Provider value={state}>{children}</BoardContext.Provider>

--- a/src/EventBus.ts
+++ b/src/EventBus.ts
@@ -3,6 +3,7 @@ import { EventEmitter2 as EventEmitter } from "eventemitter2";
 import { BusEvent } from "./types";
 
 function showWarning(msg: string) {
+  /* istanbul ignore next */
   if (process && process.env && process.env.NODE_ENV !== "production") {
     console.warn(msg);
   }

--- a/src/EventBus.ts
+++ b/src/EventBus.ts
@@ -1,6 +1,6 @@
 // Using EventEmitter2 in order to be able to use wildcards to subscribe to all events
 import { EventEmitter2 as EventEmitter } from "eventemitter2";
-import { BusEvent } from "./types";
+import { BusEvent, EventTypeDescriptor, EventCreatorFn } from "./types";
 
 function showWarning(msg: string) {
   /* istanbul ignore next */
@@ -9,16 +9,7 @@ function showWarning(msg: string) {
   }
 }
 
-type EventTypeDescriptor<T extends { type: string }> = {
-  eventType: T["type"];
-};
-
 type PredicateFn = (...args: any[]) => boolean;
-
-export type EventCreatorFn<T extends { type: string; payload: any }> = ((
-  payload: T["payload"]
-) => T) &
-  EventTypeDescriptor<T>;
 
 function isEventDescriptor<T extends { type: string }>(
   descriptor: any

--- a/src/react.test.tsx
+++ b/src/react.test.tsx
@@ -6,7 +6,7 @@ import { BusProvider, useBus, useBusReducer, useBusState } from "./react";
 import { _defaultSubscriber } from "./useBusReducer";
 import { EventBus, createEventDefinition } from "./EventBus";
 import { EventEmitter2 } from "eventemitter2";
-
+import { SubscribeFn } from "./types";
 const bus = new EventBus();
 
 function mockEventBus() {
@@ -29,9 +29,9 @@ it("should provide a bus", () => {
 it("should not subscribe without unsubscribing (useBusReducer)", () => {
   const mockBus = mockEventBus();
   // run once to subscribe to bus
-  type SubscribeFn = (d: any, b: any) => void;
+  // type SubscribeFn = (d: any, b: any) => void;
   const hook = renderHook(
-    (subscriberFn: SubscribeFn) => {
+    (subscriberFn: SubscribeFn<any>) => {
       const useReducer = useBusReducer.configure({ subscriber: subscriberFn });
       return useReducer((state: {}) => state, {}, (a: any) => a);
     },
@@ -129,7 +129,7 @@ it("should subscribe state", () => {
     () => {
       const useReducer = useBusReducer.configure({
         subscriber: (dispatch, bus) => {
-          bus.subscribe("count.**", dispatch);
+          return bus.subscribe("count.**", dispatch);
         }
       });
       return useReducer(

--- a/src/react.test.tsx
+++ b/src/react.test.tsx
@@ -28,11 +28,13 @@ it("should provide a bus", () => {
 
 it("should not subscribe without unsubscribing (useBusReducer)", () => {
   const mockBus = mockEventBus();
-
   // run once to subscribe to bus
+  type SubscribeFn = (d: any, b: any) => void;
   const hook = renderHook(
-    (subscriberFn: (d: any, b: any) => void) =>
-      useBusReducer({}, (state: {}) => state, subscriberFn),
+    (subscriberFn: SubscribeFn) => {
+      const useReducer = useBusReducer.configure({ subscriber: subscriberFn });
+      return useReducer((state: {}) => state, {}, (a: any) => a);
+    },
     {
       wrapper: ({ children }: { children?: React.ReactNode }) => (
         <BusProvider value={mockBus}>{children}</BusProvider>
@@ -54,14 +56,11 @@ it("should not subscribe without unsubscribing (useBusState)", () => {
   const incrementEvent = createEventDefinition<number>()("increment");
 
   // run once to subscribe to bus
-  const hook = renderHook(() =>
-    useBusState(0, incrementEvent),
-    {
-      wrapper: ({ children }: { children?: React.ReactNode }) => (
-        <BusProvider value={mockBus}>{children}</BusProvider>
-      )
-    }
-  );
+  const hook = renderHook(() => useBusState(0, incrementEvent), {
+    wrapper: ({ children }: { children?: React.ReactNode }) => (
+      <BusProvider value={mockBus}>{children}</BusProvider>
+    )
+  });
 
   hook.unmount();
 
@@ -71,12 +70,10 @@ it("should not subscribe without unsubscribing (useBusState)", () => {
 
 it("should update state", () => {
   const incrementEvent = createEventDefinition<number>()("increment");
-  
-  const { result } = renderHook(
-    () =>
-      useBusState(0, incrementEvent),
-    { wrapper }
-  );
+
+  const { result } = renderHook(() => useBusState(0, incrementEvent), {
+    wrapper
+  });
 
   expect(result.current).toBe(0);
 
@@ -91,7 +88,6 @@ it("should reduce state", () => {
   const { result } = renderHook(
     () =>
       useBusReducer(
-        { counter: 0 },
         (
           state: { counter: number },
           event: { type: string; payload: number }
@@ -111,7 +107,9 @@ it("should reduce state", () => {
             }
           }
           return state;
-        }
+        },
+        { counter: 0 },
+        (a: any) => a
       ),
     { wrapper }
   );
@@ -128,9 +126,13 @@ it("should reduce state", () => {
 
 it("should subscribe state", () => {
   const { result } = renderHook(
-    () =>
-      useBusReducer(
-        { counter: 0 },
+    () => {
+      const useReducer = useBusReducer.configure({
+        subscriber: (dispatch, bus) => {
+          bus.subscribe("count.**", dispatch);
+        }
+      });
+      return useReducer(
         (
           state: { counter: number },
           event: { type: string; payload: number }
@@ -157,10 +159,9 @@ it("should subscribe state", () => {
           }
           return state;
         },
-        (dispatch, bus) => {
-          bus.subscribe("count.**", dispatch);
-        }
-      ),
+        { counter: 0 }
+      );
+    },
     { wrapper }
   );
 
@@ -183,7 +184,7 @@ it("should not loose events during the render cycle when mounted.", done => {
   const EVENT_URGENT = { type: "myevent", payload: "URGENT" };
 
   function MyContextProvider(props: { children: any }) {
-    useBusReducer({}, reducer);
+    useBusReducer(reducer, {});
 
     return props.children;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,27 @@
+import { EventBus } from "./EventBus";
+
 export type BusEvent<T extends object = any> = {
   type: string;
   payload: T;
   meta?: any;
 };
 
+export type EventTypeDescriptor<T extends { type: string }> = {
+  eventType: T["type"];
+};
+
 export type EventFrom<T extends (...args: any) => BusEvent> = ReturnType<T>;
+
+export type DispatchFn<E> = (a: E) => void;
+
+type UnsubscribeFn = () => any;
+
+export type SubscribeFn<E extends BusEvent> = (
+  dispatch: DispatchFn<E>,
+  bus: EventBus
+) => UnsubscribeFn;
+
+export type EventCreatorFn<T extends { type: string; payload: any }> = ((
+  payload: T["payload"]
+) => T) &
+  EventTypeDescriptor<T>;

--- a/src/useBusReducer.ts
+++ b/src/useBusReducer.ts
@@ -1,14 +1,7 @@
 import { useReducer, useLayoutEffect } from "react";
 import { useBus } from "./react";
 import { EventBus } from "./EventBus";
-import { BusEvent } from "./types";
-
-type DispatchFn<E> = (a: E) => void;
-
-type SubScriberFn<E extends BusEvent> = (
-  dispatch: DispatchFn<E>,
-  bus: EventBus
-) => void;
+import { DispatchFn, SubscribeFn, BusEvent } from "./types";
 
 type InitFn<T> = (a: any) => T;
 type ReducerFn<S, E> = (s: S, e: E) => S;
@@ -25,7 +18,7 @@ export function _defaultSubscriber<E extends BusEvent>(
 }
 
 const useReducerCreator = <E extends BusEvent = BusEvent, T = any>(
-  subscriber: SubScriberFn<E>
+  subscriber: SubscribeFn<E>
 ) => (
   reducer: ReducerFn<T, E>,
   initState: any,
@@ -54,7 +47,7 @@ export function useBusReducer<E extends BusEvent = BusEvent, T = any>(
 }
 
 type UseBusReducerOptions<E extends BusEvent> = {
-  subscriber: SubScriberFn<E>;
+  subscriber: SubscribeFn<E>;
 };
 
 useBusReducer.configure = <E extends BusEvent = BusEvent>(

--- a/src/useBusState.ts
+++ b/src/useBusState.ts
@@ -1,7 +1,6 @@
-import { useEffect, useState, Dispatch, SetStateAction, useLayoutEffect } from "react";
+import { useState, useLayoutEffect } from "react";
 import { useBus } from "./react";
-import { BusEvent } from "./types";
-import { EventCreatorFn } from './EventBus';
+import { EventCreatorFn, BusEvent } from "./types";
 
 export function useBusState<E extends BusEvent = BusEvent>(
   initState: E["payload"] | undefined,
@@ -12,8 +11,12 @@ export function useBusState<E extends BusEvent = BusEvent>(
   const [state, dispatch] = useState<E["payload"]>(initState);
 
   useLayoutEffect(() => {
-    const unsubscribe = bus.subscribe<E>(event, (v: E) => { dispatch(v.payload) });
-    return () => { unsubscribe() };
+    const unsubscribe = bus.subscribe<E>(event, (v: E) => {
+      dispatch(v.payload);
+    });
+    return () => {
+      unsubscribe();
+    };
   }, [dispatch, bus]);
 
   return state;


### PR DESCRIPTION
This PR provides a draft of the configuration syntax:

* Swap useBusReducer input args to be more inline with useReducer https://github.com/ryardley/ts-bus/issues/22

This makes `useBusReducer` more inline with React's `useReducer` which should be more intuitive for new users of the library.

```ts
import {useBusReducer} from 'ts-bus/react';

// The output shares the exact signature of the React equivalent
// This would be a breaking change 
const state = useBusReducer(reducer, initState, init);
import {useBusReducer} from 'ts-bus/react';

// Create a configured useReducer function
const useReducer = useBusReducer.configure({subscriber});

// The output shares the exact signature of the React equivalent but with the configuration applied
const state = useReducer(reducer, initState, init);
```

This also acts as preparation for these PRs:
* Accept injected useReducer function to enable reinspect to attach to bus https://github.com/ryardley/ts-bus/issues/18 (by passing in a config object)
* useBusReducer pass in subscriber filter https://github.com/ryardley/ts-bus/issues/15 (can possibly provide a new property function for short handing typing need to workshop this one a little but this pattern is far more flexible)