### PR TITLE
useBusState subscriber option

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,3 +445,22 @@ function Counter() {
   );
 }
 ```
+
+#### useBusState configuration
+
+You can configure useBusState with a subscriber passing in an options object.
+
+```ts
+// get a new useState function
+const useState = useBusState.configure({
+    subscriber: (dispatch, bus) => bus.subscribe("**", (ev) => dispatch(ev.payload))
+});
+
+const state = useState(/*...*/);
+```
+
+Available options:
+
+| Option     | Description         |
+| ---------- | ------------------- |
+| subscriber | Subscriber function |

--- a/src/react.test.tsx
+++ b/src/react.test.tsx
@@ -68,6 +68,25 @@ it("should not subscribe without unsubscribing (useBusState)", () => {
   expect(mockBus._unsubscribe.mock.calls.length).toBe(1);
 });
 
+it("should update state (options configuration)", () => {
+  const incrementEvent = createEventDefinition<number>()("counter.increment");
+
+  const { result } = renderHook(() => 
+    useBusState.configure({subscriber: (dispatch, bus) => {
+      return bus.subscribe("counter.**", (v) => dispatch(v.payload));
+    }})(0), {
+    wrapper
+  });
+
+  expect(result.current).toBe(0);
+
+  act(() => {
+    bus.publish(incrementEvent(1));
+  });
+
+  expect(result.current).toBe(1);
+});
+
 it("should update state", () => {
   const incrementEvent = createEventDefinition<number>()("increment");
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,11 @@ export type SubscribeFn<E extends BusEvent> = (
   bus: EventBus
 ) => UnsubscribeFn;
 
+export type SubscribeWithPayloadDispatchFn<E extends BusEvent> = (
+  dispatch: DispatchFn<E["payload"]>,
+  bus: EventBus
+) => UnsubscribeFn;
+
 export type EventCreatorFn<T extends { type: string; payload: any }> = ((
   payload: T["payload"]
 ) => T) &

--- a/src/useBusState.ts
+++ b/src/useBusState.ts
@@ -5,7 +5,7 @@ import { EventCreatorFn, BusEvent, SubscribeWithPayloadDispatchFn } from './type
 const useStateCreator = <E extends BusEvent = BusEvent>(
   subscriber: SubscribeWithPayloadDispatchFn<E>
 ) => (
-  initState: E["payload"] | undefined
+  initState: E["payload"] | (() => E["payload"])
 ) => {
     const bus = useBus();
 

--- a/src/useBusState.ts
+++ b/src/useBusState.ts
@@ -1,6 +1,20 @@
 import { useState, useLayoutEffect } from "react";
 import { useBus } from "./react";
-import { EventCreatorFn, BusEvent } from "./types";
+import { EventCreatorFn, BusEvent, SubscribeWithPayloadDispatchFn } from './types';
+
+const useStateCreator = <E extends BusEvent = BusEvent>(
+  subscriber: SubscribeWithPayloadDispatchFn<E>
+) => (
+  initState: E["payload"] | undefined
+) => {
+    const bus = useBus();
+
+    const [state, dispatch] = useState<E["payload"]>(initState);
+
+    useLayoutEffect(() => subscriber(dispatch, bus), [dispatch, bus]);
+
+    return state;
+  };
 
 export function useBusState<E extends BusEvent = BusEvent>(
   initState: E["payload"] | undefined,
@@ -8,16 +22,18 @@ export function useBusState<E extends BusEvent = BusEvent>(
 ): E["payload"] {
   const bus = useBus();
 
-  const [state, dispatch] = useState<E["payload"]>(initState);
-
-  useLayoutEffect(() => {
-    const unsubscribe = bus.subscribe<E>(event, (v: E) => {
-      dispatch(v.payload);
-    });
-    return () => {
-      unsubscribe();
-    };
-  }, [dispatch, bus]);
-
-  return state;
+  const useState = useStateCreator((dispatch, bus) => {
+    return bus.subscribe(event, (ev: E) => dispatch(ev.payload))
+  });
+  return useState(initState);
 }
+
+type UseBusStateOptions<E extends BusEvent> = {
+  subscriber: SubscribeWithPayloadDispatchFn<E>;
+};
+
+useBusState.configure = <E extends BusEvent = BusEvent>(
+  options: UseBusStateOptions<E>
+) => {
+  return useStateCreator(options.subscriber);
+};


### PR DESCRIPTION
useBusState implementation of [#35](https://github.com/ryardley/ts-bus/pull/35).
@ryardley the dispatch is slightly different compared to `useBusReducer`. It dispatches only the payload of the event. Reason is because I think for useBusState, only the payload is/should be relevant. If you need event information, then `useBusReducer` is probably a better choice in most cases.