### PR TITLE
Allow PredicateFn to return a type predicate

### DIFF
--- a/src/EventBus.ts
+++ b/src/EventBus.ts
@@ -14,7 +14,7 @@ function showWarning(msg: string) {
   }
 }
 
-export type PredicateFn<T> = (event: T) => boolean;
+type PredicateFn<T> = (event: T) => boolean | ((event: T) => event is T);
 
 function isEventDescriptor<T extends { type: string }>(
   descriptor: any


### PR DESCRIPTION
I found myself wanting to have a predicate function that both specified a specific type of event, but also filters further based on criteria that doesn't change the event type - this allows for the latter while still maintaining the type info of the former. Let me know if you have any concerns or if there's a better way of doing this.